### PR TITLE
SRE-1220 fix directory paths for component builds

### DIFF
--- a/docker-images/4.2/alpine/Dockerfile
+++ b/docker-images/4.2/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN     apk  add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1
 
 FROM        base AS build
 
-WORKDIR     ffmpeg_build_tmp
+WORKDIR     ffmpeg_build
 
 ARG        PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
 ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
@@ -78,7 +78,7 @@ RUN     buildDeps="autoconf \
         apk  add --no-cache --update ${buildDeps}
 ## opencore-amr https://sourceforge.net/projects/opencore-amr/
 RUN \
-        DIR=ffmpeg_build_tmp/opencore-amr && \
+        DIR=opencore-amr && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://versaweb.dl.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-${OPENCOREAMR_VERSION}.tar.gz | \
@@ -89,7 +89,7 @@ RUN \
         rm -rf ${DIR}
 ## x264 http://www.videolan.org/developers/x264.html
 RUN \
-        DIR=ffmpeg_build_tmp/x264 && \
+        DIR=x264 && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
@@ -100,7 +100,7 @@ RUN \
         rm -rf ${DIR}
 ### x265 http://x265.org/
 RUN \
-        DIR=ffmpeg_build_tmp/x265 && \
+        DIR=x265 && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://download.videolan.org/pub/videolan/x265/x265_${X265_VERSION}.tar.gz  | \
@@ -113,7 +113,7 @@ RUN \
         rm -rf ${DIR}
 ### libogg https://www.xiph.org/ogg/
 RUN \
-        DIR=ffmpeg_build_tmp/ogg && \
+        DIR=ogg && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz && \
@@ -125,7 +125,7 @@ RUN \
         rm -rf ${DIR}
 ### libopus https://www.opus-codec.org/
 RUN \
-        DIR=ffmpeg_build_tmp/opus && \
+        DIR=opus && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://archive.mozilla.org/pub/opus/opus-${OPUS_VERSION}.tar.gz && \
@@ -138,7 +138,7 @@ RUN \
         rm -rf ${DIR}
 ### libvorbis https://xiph.org/vorbis/
 RUN \
-        DIR=ffmpeg_build_tmp/vorbis && \
+        DIR=vorbis && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz && \
@@ -150,7 +150,7 @@ RUN \
         rm -rf ${DIR}
 ### libtheora http://www.theora.org/
 RUN \
-        DIR=ffmpeg_build_tmp/theora && \
+        DIR=theora && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.gz && \
@@ -162,7 +162,7 @@ RUN \
         rm -rf ${DIR}
 ### libvpx https://www.webmproject.org/code/
 RUN \
-        DIR=ffmpeg_build_tmp/vpx && \
+        DIR=vpx && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | \
@@ -174,7 +174,7 @@ RUN \
         rm -rf ${DIR}
 ### libwebp https://developers.google.com/speed/webp/
 RUN \
-        DIR=ffmpeg_build_tmp/vebp && \
+        DIR=vebp && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP_VERSION}.tar.gz | \
@@ -185,7 +185,7 @@ RUN \
         rm -rf ${DIR}
 ### libmp3lame http://lame.sourceforge.net/
 RUN \
-        DIR=ffmpeg_build_tmp/lame && \
+        DIR=lame && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://versaweb.dl.sourceforge.net/project/lame/lame/$(echo ${LAME_VERSION} | sed -e 's/[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)/\1.\2/')/lame-${LAME_VERSION}.tar.gz | \
@@ -196,7 +196,7 @@ RUN \
         rm -rf ${DIR}
 ### xvid https://www.xvid.com/
 RUN \
-        DIR=ffmpeg_build_tmp/xvid && \
+        DIR=xvid && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz && \
@@ -209,7 +209,7 @@ RUN \
         rm -rf ${DIR}
 ### fdk-aac https://github.com/mstorsjo/fdk-aac
 RUN \
-        DIR=ffmpeg_build_tmp/fdk-aac && \
+        DIR=fdk-aac && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | \
@@ -221,7 +221,7 @@ RUN \
         rm -rf ${DIR}
 ## openjpeg https://github.com/uclouvain/openjpeg
 RUN \
-        DIR=ffmpeg_build_tmp/openjpeg && \
+        DIR=openjpeg && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sL https://github.com/uclouvain/openjpeg/archive/v${OPENJPEG_VERSION}.tar.gz | \
@@ -232,7 +232,7 @@ RUN \
         rm -rf ${DIR}
 ## freetype https://www.freetype.org/
 RUN  \
-        DIR=ffmpeg_build_tmp/freetype && \
+        DIR=freetype && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
@@ -244,7 +244,7 @@ RUN  \
         rm -rf ${DIR}
 ## libvstab https://github.com/georgmartius/vid.stab
 RUN  \
-        DIR=ffmpeg_build_tmp/vid.stab && \
+        DIR=vid.stab && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://github.com/georgmartius/vid.stab/archive/v${LIBVIDSTAB_VERSION}.tar.gz &&\
@@ -257,7 +257,7 @@ RUN  \
 ## fridibi https://www.fribidi.org/
 # + https://github.com/fribidi/fribidi/issues/8
 RUN  \
-        DIR=ffmpeg_build_tmp/fribidi && \
+        DIR=fribidi && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://github.com/fribidi/fribidi/archive/${FRIBIDI_VERSION}.tar.gz && \
@@ -271,7 +271,7 @@ RUN  \
         rm -rf ${DIR}
 ## fontconfig https://www.freedesktop.org/wiki/Software/fontconfig/
 RUN  \
-        DIR=ffmpeg_build_tmp/fontconfig && \
+        DIR=fontconfig && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://www.freedesktop.org/software/fontconfig/release/fontconfig-${FONTCONFIG_VERSION}.tar.bz2 &&\
@@ -282,7 +282,7 @@ RUN  \
         rm -rf ${DIR}
 ## libass https://github.com/libass/libass
 RUN  \
-        DIR=ffmpeg_build_tmp/libass && \
+        DIR=libass && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://github.com/libass/libass/archive/${LIBASS_VERSION}.tar.gz &&\
@@ -295,7 +295,7 @@ RUN  \
         rm -rf ${DIR}
 ## kvazaar https://github.com/ultravideo/kvazaar
 RUN \
-        DIR=ffmpeg_build_tmp/kvazaar && \
+        DIR=kvazaar && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sLO https://github.com/ultravideo/kvazaar/archive/v${KVAZAAR_VERSION}.tar.gz &&\
@@ -307,7 +307,7 @@ RUN \
         rm -rf ${DIR}
 
 RUN \
-	DIR=ffmpeg_build_tmp/aom && \
+	DIR=aom && \
         git clone --branch ${AOM_VERSION} --depth 1 https://aomedia.googlesource.com/aom ${DIR} ; \
         cd ${DIR} ; \
         rm -rf CMakeCache.txt CMakeFiles ; \
@@ -320,14 +320,14 @@ RUN \
 
 ## ffmpeg https://ffmpeg.org/
 RUN  \
-        DIR=ffmpeg_build_tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
+        DIR=ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
         curl -sLO https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
         tar -jx --strip-components=1 -f ffmpeg-${FFMPEG_VERSION}.tar.bz2
 
 
 
 RUN \
-        DIR=ffmpeg_build_tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
+        DIR=ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
         ./configure \
         --disable-debug \
         --disable-doc \


### PR DESCRIPTION
https://ujetcs.atlassian.net/browse/SRE-1220

I forgot that WORKDIR would be the CWD for docker RUN commands. So I ended up building each component in a subdirectory with the same name as the parent directory. No harm but is curious at best so I decided to fix to avoid confusion. See https://jenkins.inf.ujet.xyz/view/Build/job/ffmpeg-static-build/7/consoleFull. This change replaces build paths such as "/ffmpeg_build_tmp/ffmpeg_build_tmp/$component" with "ffmpeg_build/$component".